### PR TITLE
moved onClickListener for favorites from init to bind, fixing bug whe…

### DIFF
--- a/app/src/main/java/com/appsontap/bernie2020/legislation/LegislationViewHolder.kt
+++ b/app/src/main/java/com/appsontap/bernie2020/legislation/LegislationViewHolder.kt
@@ -38,14 +38,6 @@ class LegislationViewHolder(itemView: View, private val uiState: UiState.ListRea
                     .commit()
             }
         }
-        itemView.checkbox_favorite?.setOnClickListener {
-            val legislation = uiState.items[adapterPosition] as Legislation
-            if (itemView.checkbox_favorite.isChecked) {
-                IOHelper.addFavoriteToSharedPrefs(itemView.context, legislation.id)
-            } else {
-                IOHelper.removeFavoriteFromSharedPrefs(itemView.context, legislation.id)
-            }
-        }
 
         itemView.imageview_share?.setOnClickListener {
             val sendIntent = Intent().apply {
@@ -60,5 +52,12 @@ class LegislationViewHolder(itemView: View, private val uiState: UiState.ListRea
     fun bind(legislation: Legislation, favorites: Set<String>) {
         itemView.textview_name.text = legislation.name
         itemView.checkbox_favorite?.isChecked = favorites.contains(legislation.id)
+        itemView.checkbox_favorite?.setOnClickListener {
+            if (itemView.checkbox_favorite.isChecked) {
+                IOHelper.addFavoriteToSharedPrefs(itemView.context, legislation.id)
+            } else {
+                IOHelper.removeFavoriteFromSharedPrefs(itemView.context, legislation.id)
+            }
+        }
     }
 }


### PR DESCRIPTION
…re the favorite would jump to another item in hte same relative location when a search was canceled.